### PR TITLE
Refine MudBlazor theme and style drawer navigation links

### DIFF
--- a/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.Razor.cs
+++ b/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.Razor.cs
@@ -10,23 +10,48 @@ public static class RohTheme
         PaletteDark = new PaletteDark
         {
             Primary = "#c9a24d",        // Aged gold
-            Secondary = "#3a6ea5",      // Blue accent
-            Background = "#070a14",
+            Secondary = "#3f6f98",      // Blue steel
+            Background = "#05070f",
             Surface = "#0b0f1e",
-            DrawerBackground = "#0b0f1e",
+            DrawerBackground = "#0a0e1a",
             AppbarBackground = "#121735",
-            TextPrimary = "#e6e8ef",
-            TextSecondary = "#b8bccb",
-            Divider = "rgba(255,255,255,0.08)",
-            AppbarText = "#c9a24d",
-            PrimaryDarken = "#c9a24d",
-            DrawerIcon = "#c9a24d"
+            TextPrimary = "#eef0f6",
+            TextSecondary = "#b5bccb",
+            Divider = "rgba(201,162,77,0.18)",
+            AppbarText = "#e6c77a",
+            PrimaryDarken = "#b38b3f",
+            DrawerIcon = "#d9b15e",
+            ActionDefault = "#c9a24d",
+            ActionDisabled = "rgba(201,162,77,0.45)",
+            ActionDisabledBackground = "rgba(201,162,77,0.12)"
+        },
+
+        Typography = new Typography
+        {
+            Default = new DefaultTypography
+            {
+                FontFamily = new[] { "Cinzel", "Trajan Pro", "serif" },
+                FontSize = "0.98rem",
+                FontWeight = 400
+            },
+            H6 = new H6Typography
+            {
+                FontFamily = new[] { "Cinzel", "Trajan Pro", "serif" },
+                FontWeight = 600,
+                LetterSpacing = "0.18em"
+            },
+            Subtitle1 = new Subtitle1Typography
+            {
+                FontFamily = new[] { "Cinzel", "Trajan Pro", "serif" },
+                FontWeight = 500,
+                LetterSpacing = "0.12em"
+            }
         },
 
         LayoutProperties = new LayoutProperties
         {
             AppbarHeight = "64px",
-            DrawerWidthLeft = "260px"
+            DrawerWidthLeft = "280px"
         }
     };
 }

--- a/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.razor
+++ b/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.razor
@@ -17,27 +17,23 @@
 <MudSnackbarProvider />
 
 <MudLayout>
-    <MudAppBar>
+    <MudAppBar Class="roh-appbar">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu"
+                       Color="Color.Inherit"
+                       Edge="Edge.Start"
+                       OnClick="@ToggleDrawer" />
 
+        <MudText Typo="Typo.h6"
+                 Color="Color.Inherit"
+                 Class="roh-appbar-title">
+            Reign of Humanae
+        </MudText>
 
+        <MudSpacer />
 
-            <MudIconButton Icon="@Icons.Material.Filled.Menu"
-                           Color="Color.Inherit"
-                           Edge="Edge.Start"
-                           OnClick="@ToggleDrawer" />
-
-            <MudText Typo="Typo.h6"
-                     Color="Color.Inherit">
-                Reign of Humanae
-            </MudText>
-
-            <MudSpacer />
-
-            <MudIconButton Icon="@Icons.Material.Filled.AccountCircle"
-                           Color="Color.Inherit"
-                           OnClick="@(() => Navigation.NavigateTo("/login"))" />
-
-
+        <MudIconButton Icon="@Icons.Material.Filled.AccountCircle"
+                       Color="Color.Inherit"
+                       OnClick="@(() => Navigation.NavigateTo("/login"))" />
     </MudAppBar>
 
     <MudDrawer @bind-Open="_drawerOpen"
@@ -45,9 +41,13 @@
                Class="roh-drawer">
 
         <!-- Drawer content later -->
-        <MudNavMenu>
-            <MudNavLink Href="/" Match="NavLinkMatch.All">Home</MudNavLink>
-            <MudNavLink Href="/login">Login</MudNavLink>
+        <MudNavMenu Class="roh-navmenu">
+            <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
+                Home
+            </MudNavLink>
+            <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">
+                Login
+            </MudNavLink>
         </MudNavMenu>
 
     </MudDrawer>

--- a/src/Site/ROH.Site/ROH.Site/wwwroot/app.css
+++ b/src/Site/ROH.Site/ROH.Site/wwwroot/app.css
@@ -34,13 +34,44 @@ body {
     border-right: 1px solid rgba(201, 162, 77, 0.25);
 }
 
+/* Drawer navigation */
+.roh-navmenu {
+    padding: 12px;
+}
+
+    .roh-navmenu .mud-nav-link {
+        border-radius: 12px;
+        color: #e6d3a1;
+        font-family: "Cinzel", "Trajan Pro", serif;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 12px 16px;
+        transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+    }
+
+        .roh-navmenu .mud-nav-link .mud-nav-link-icon {
+            color: #d6b35e;
+            margin-right: 12px;
+        }
+
+        .roh-navmenu .mud-nav-link:hover {
+            background: rgba(201, 162, 77, 0.12);
+            box-shadow: inset 0 0 0 1px rgba(201, 162, 77, 0.35);
+            transform: translateX(2px);
+        }
+
+        .roh-navmenu .mud-nav-link.active {
+            background: rgba(201, 162, 77, 0.2);
+            box-shadow: inset 0 0 0 1px rgba(201, 162, 77, 0.6);
+        }
+
 /* Content offset */
 .roh-content {
     padding-top: 64px;
 }
 
 /* ===============================
-   ROH – MudBlazor AppBar
+   ROH ï¿½ MudBlazor AppBar
    =============================== */
 
 .mud-appbar {


### PR DESCRIPTION
### Motivation
- Align the site's main layout visuals with the Reign of Humanae design language by refining the MudBlazor theme palette and typography. 
- Improve the drawer navigation appearance so `MudNavLink` items match the site design with icons and clearer styling. 
- Small layout tweaks to spacing and drawer width to accommodate the updated visual treatments.

### Description
- Add `Class="roh-appbar"` to the `MudAppBar` and `Class="roh-appbar-title"` to the title in `MainLayout.razor` to enable custom appbar styling. 
- Enhance drawer menu by adding `Class="roh-navmenu"` to `MudNavMenu` and include icons for `MudNavLink` items (Home and Login) in `MainLayout.razor`. 
- Refine `RohTheme.Dark` in `MainLayout.Razor.cs` by adjusting palette values (`Primary`, `Secondary`, backgrounds, text colors, action colors), adding `Typography` overrides, and increasing `DrawerWidthLeft` to `280px`. 
- Add CSS rules to `wwwroot/app.css` to style `.roh-navmenu` and `.mud-nav-link` states (hover/active), icon color, padding, and typography to match the theme.

### Testing
- Attempted to run the site with `dotnet run --project src/Site/ROH.Site/ROH.Site/ROH.Site.csproj`, but the environment does not have `dotnet` installed so runtime verification could not be executed. 
- File updates were applied and staged, and a commit was created (`git commit` completed) confirming the changes were written to disk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69813673f6688330a9fd5a0382ba9f0e)