### PR TITLE
Substituir MatBlazor por MudBlazor em páginas e completar menu lateral

### DIFF
--- a/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.razor
+++ b/src/Site/ROH.Site/ROH.Site/Components/Layout/MainLayout.razor
@@ -45,8 +45,38 @@
             <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
                 Home
             </MudNavLink>
-            <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">
-                Login
+            <MudNavGroup Title="Account" Icon="@Icons.Material.Filled.AccountCircle">
+                <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">
+                    Login
+                </MudNavLink>
+                <MudNavLink Href="/createaccount" Icon="@Icons.Material.Filled.PersonAdd">
+                    Create Account
+                </MudNavLink>
+            </MudNavGroup>
+            <MudNavGroup Title="Lore" Icon="@Icons.Material.Filled.MenuBook">
+                <MudNavLink Href="/lore" Icon="@Icons.Material.Filled.AutoStories">
+                    Lore
+                </MudNavLink>
+                <MudNavLink Href="/races" Icon="@Icons.Material.Filled.Groups">
+                    Races
+                </MudNavLink>
+                <MudNavLink Href="/crafting" Icon="@Icons.Material.Filled.Handyman">
+                    Crafting
+                </MudNavLink>
+                <MudNavLink Href="/magic-skills" Icon="@Icons.Material.Filled.AutoFixHigh">
+                    Magic Skills
+                </MudNavLink>
+                <MudNavLink Href="/world-bosses" Icon="@Icons.Material.Filled.Public">
+                    World Bosses
+                </MudNavLink>
+            </MudNavGroup>
+            <MudNavGroup Title="Manager" Icon="@Icons.Material.Filled.Build">
+                <MudNavLink Href="/manager/version/versionmanager" Icon="@Icons.Material.Filled.Settings">
+                    Version Manager
+                </MudNavLink>
+            </MudNavGroup>
+            <MudNavLink Href="/test" Icon="@Icons.Material.Filled.Science">
+                Test
             </MudNavLink>
         </MudNavMenu>
 

--- a/src/Site/ROH.Site/ROH.Site/Components/Pages/Account/CreateAccount.razor
+++ b/src/Site/ROH.Site/ROH.Site/Components/Pages/Account/CreateAccount.razor
@@ -10,21 +10,37 @@
 <CardComponent Header="Create Account">
     @if (isLoading)
     {
-        <div style="text-align:center">
-            <div class="spinner-border text-primary" role="status">
-                <span class="sr-only"></span>
-            </div>
-        </div>
+        <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center">
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Large" />
+        </MudStack>
     }
     else
     {
-@*         <div class="center-content">
-            <MatInputTextComponent Label="Email" @bind-Value="@EmailValue"></MatInputTextComponent>
-            <MatInputTextComponent Label="Username" @bind-Value="@UsernameValue"></MatInputTextComponent>
-            <MatInputTextComponent Label="Password" @bind-Value="@PasswordValue" Type="password"></MatInputTextComponent>
-            <MatInputTextComponent Label="Confirm Password" @bind-Value="@ConfirmPasswordValue" Type="password"></MatInputTextComponent>
-            <MatButton OnClick="Confirm" Style="margin:10px">Create Account</MatButton>
-        </div> *@
+        <MudStack Spacing="2">
+            <MudTextField T="string"
+                          Label="Email"
+                          Variant="Variant.Outlined"
+                          @bind-Value="@EmailValue" />
+            <MudTextField T="string"
+                          Label="Username"
+                          Variant="Variant.Outlined"
+                          @bind-Value="@UsernameValue" />
+            <MudTextField T="string"
+                          Label="Password"
+                          Variant="Variant.Outlined"
+                          InputType="InputType.Password"
+                          @bind-Value="@PasswordValue" />
+            <MudTextField T="string"
+                          Label="Confirm Password"
+                          Variant="Variant.Outlined"
+                          InputType="InputType.Password"
+                          @bind-Value="@ConfirmPasswordValue" />
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="Confirm">
+                Create Account
+            </MudButton>
+        </MudStack>
     }
 </CardComponent>
 

--- a/src/Site/ROH.Site/ROH.Site/Components/Pages/Account/Login.razor
+++ b/src/Site/ROH.Site/ROH.Site/Components/Pages/Account/Login.razor
@@ -11,25 +11,30 @@
 @inject ICustomAuthenticationStateProvider _customAuthenticationStateProviderProvider;
 
 <CardComponent Header="Login">
-@*     <div class="center-content">
-        <MatInputTextComponent Label="Login" @bind-Value="@LoginValue"></MatInputTextComponent>
-        <MatInputTextComponent Label="Password" @bind-Value="@PasswordValue" Type="password"></MatInputTextComponent>
-        <div class="row" style="margin-top:10px">
-            <div class="col-auto">
-                <MatButton OnClick="Confirm">Confirm</MatButton>
-            </div>
-        </div>
-        <div class="row" style="margin-top:10px">
-            <div class="col-auto">
-                <MatButton OnClick="@(() => Navigation.NavigateTo("/createaccount"))">New Account</MatButton>
-            </div>
-        </div>
-        <div class="row" style="margin-top:10px">
-            <div class="col-auto">
-                <MatButton>Forgot Password</MatButton>
-            </div>
-        </div>
-    </div> *@
+    <MudStack Spacing="2">
+        <MudTextField T="string"
+                      Label="Login"
+                      Variant="Variant.Outlined"
+                      @bind-Value="@LoginValue" />
+        <MudTextField T="string"
+                      Label="Password"
+                      Variant="Variant.Outlined"
+                      InputType="InputType.Password"
+                      @bind-Value="@PasswordValue" />
+        <MudStack Direction="Row" Spacing="2">
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Confirm">
+                Confirm
+            </MudButton>
+            <MudButton Color="Color.Secondary"
+                       Variant="Variant.Outlined"
+                       OnClick="@(() => Navigation.NavigateTo("/createaccount"))">
+                New Account
+            </MudButton>
+            <MudButton Color="Color.Default" Variant="Variant.Text">
+                Forgot Password
+            </MudButton>
+        </MudStack>
+    </MudStack>
 </CardComponent>
 
 @code {
@@ -62,4 +67,3 @@
 
 
 }
-

--- a/src/Site/ROH.Site/ROH.Site/Components/Pages/Manager/Version/VersionDetails.razor
+++ b/src/Site/ROH.Site/ROH.Site/Components/Pages/Manager/Version/VersionDetails.razor
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="col-sm-12">
                     <div class="text-center">
-                        <MatProgressBar Progress="@(uploadProgress/100)" />
+                        <MudProgressLinear Value="uploadProgress" Color="Color.Primary" />
                         <p>Uploading... (@uploadProgress%)</p>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Unificar a UI do site trocando componentes MatBlazor por equivalentes MudBlazor para manter o estilo e consistência visual.
- Disponibilizar navegação para as demais páginas no drawer para acesso direto às seções de lore, conta e gerenciamento.

### Description
- Replaced Mat components in `Components/Pages/Account/Login.razor` with MudBlazor components (`MudTextField`, `MudButton`, `MudStack`) and preserved the `CardComponent` wrapper.
- Replaced Mat components in `Components/Pages/Account/CreateAccount.razor` with MudBlazor components (`MudTextField`, `MudButton`, `MudStack`) and swapped the spinner for `MudProgressCircular`.
- Replaced `MatProgressBar` with `MudProgressLinear` in `Components/Pages/Manager/Version/VersionDetails.razor` to show upload progress.
- Added grouped navigation links in `Components/Layout/MainLayout.razor` (Account, Lore, Manager) and a `Test` link so the drawer exposes the remaining pages.

### Testing
- Verified removal of Mat components by running a repository search for `MatInputTextComponent|MatButton|MatProgressBar`, which returned no matches after changes (succeeded).
- Attempted to run the site with `dotnet run --project src/Site/ROH.Site/ROH.Site/ROH.Site.csproj`, but the command failed because `dotnet` is not available in the environment (failed).
- No in-place build/test was possible in this environment, so compilation and runtime behavior should be validated locally or in CI with `dotnet build` / `dotnet run`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e5a61ef88330a18000850f0b4a05)